### PR TITLE
Make the preregistration methods more flexible

### DIFF
--- a/src/LegionUtilities.hpp
+++ b/src/LegionUtilities.hpp
@@ -73,6 +73,7 @@ template <void (*TASK_PTR)(const Legion::Task *,
                            Legion::Context, Legion::Runtime *)>
 void preregister_task(Legion::TaskID task_id,
                       const std::string &task_name,
+                      Legion::Processor::Kind kind,
                       bool verbose = true) {
     if (verbose) {
         std::cout << "[LegionSolvers] Registering task " << task_name
@@ -80,7 +81,7 @@ void preregister_task(Legion::TaskID task_id,
     }
     Legion::TaskVariantRegistrar registrar{task_id, task_name.c_str()};
     registrar.add_constraint(
-        Legion::ProcessorConstraint{Legion::Processor::LOC_PROC}
+        Legion::ProcessorConstraint{kind}
     );
     Legion::Runtime::preregister_task_variant<TASK_PTR>(
         registrar, task_name.c_str()
@@ -93,6 +94,7 @@ template <void (*TASK_PTR)(const Legion::Task *,
 void preregister_task(Legion::TaskID task_id,
                       const std::string &task_name,
                       TaskFlags task_flags,
+                      Legion::Processor::Kind kind,
                       bool verbose = true) {
     if (verbose) {
         std::cout << "[LegionSolvers] Registering task " << task_name
@@ -100,7 +102,7 @@ void preregister_task(Legion::TaskID task_id,
     }
     Legion::TaskVariantRegistrar registrar{task_id, task_name.c_str()};
     registrar.add_constraint(
-        Legion::ProcessorConstraint{Legion::Processor::LOC_PROC}
+        Legion::ProcessorConstraint{kind}
     );
     registrar.set_leaf(task_flags & TaskFlags::LEAF);
     registrar.set_inner(task_flags & TaskFlags::INNER);
@@ -117,6 +119,7 @@ template <typename RETURN_T,
                                Legion::Context, Legion::Runtime *)>
 void preregister_task(Legion::TaskID task_id,
                       const std::string &task_name,
+                      Legion::Processor::Kind kind,
                       bool verbose = true) {
     if (verbose) {
         std::cout << "[LegionSolvers] Registering task " << task_name
@@ -124,7 +127,7 @@ void preregister_task(Legion::TaskID task_id,
     }
     Legion::TaskVariantRegistrar registrar{task_id, task_name.c_str()};
     registrar.add_constraint(
-        Legion::ProcessorConstraint{Legion::Processor::LOC_PROC}
+        Legion::ProcessorConstraint{kind}
     );
     if constexpr (std::is_void_v<RETURN_T>) {
         Legion::Runtime::preregister_task_variant<TASK_PTR>(
@@ -144,6 +147,7 @@ template <typename RETURN_T,
 void preregister_task(Legion::TaskID task_id,
                       const std::string &task_name,
                       TaskFlags task_flags,
+                      Legion::Processor::Kind kind,
                       bool verbose = true) {
     if (verbose) {
         std::cout << "[LegionSolvers] Registering task " << task_name
@@ -151,7 +155,7 @@ void preregister_task(Legion::TaskID task_id,
     }
     Legion::TaskVariantRegistrar registrar{task_id, task_name.c_str()};
     registrar.add_constraint(
-        Legion::ProcessorConstraint{Legion::Processor::LOC_PROC}
+        Legion::ProcessorConstraint{kind}
     );
     registrar.set_leaf(task_flags & TaskFlags::LEAF);
     registrar.set_inner(task_flags & TaskFlags::INNER);

--- a/src/TaskBaseClasses.hpp
+++ b/src/TaskBaseClasses.hpp
@@ -92,7 +92,11 @@ struct TaskT {
         preregister_task<
             typename TaskClass<T>::return_type,
             TaskClass<T>::task_body>(
-            task_id, task_name(), TaskClass<T>::flags, verbose
+            task_id,
+            task_name(),
+            TaskClass<T>::flags,
+            Legion::Processor::LOC_PROC,
+            verbose
         );
     }
 
@@ -139,7 +143,11 @@ struct TaskTDI {
         preregister_task<
             typename TaskClass<T, N, I>::return_type,
             TaskClass<T, N, I>::task_body>(
-            task_id, task_name(), TaskClass<T, N, I>::flags, verbose
+            task_id,
+            task_name(),
+            TaskClass<T, N, I>::flags,
+            Legion::Processor::LOC_PROC,
+            verbose
         );
     }
 
@@ -260,6 +268,7 @@ struct TaskTDDDIII {
             task_id,
             task_name(),
             TaskClass<T, N1, N2, N3, I1, I2, I3>::flags,
+            Legion::Processor::LOC_PROC,
             verbose
         );
     }

--- a/src/Test01ScalarOperations.cpp
+++ b/src/Test01ScalarOperations.cpp
@@ -35,7 +35,10 @@ int main(int argc, char **argv) {
     using LegionSolvers::TaskFlags;
     LegionSolvers::initialize(false);
     LegionSolvers::preregister_task<top_level_task>(
-        TOP_LEVEL_TASK_ID, "top_level", TaskFlags::REPLICABLE | TaskFlags::INNER
+        TOP_LEVEL_TASK_ID,
+        "top_level",
+        TaskFlags::REPLICABLE | TaskFlags::INNER,
+        Legion::Processor::LOC_PROC
     );
     Legion::Runtime::set_top_level_task_id(TOP_LEVEL_TASK_ID);
     return Legion::Runtime::start(argc, argv);

--- a/src/Test02VectorOperations.cpp
+++ b/src/Test02VectorOperations.cpp
@@ -170,107 +170,128 @@ int main(int argc, char **argv) {
     LegionSolvers::preregister_task<test_task<float, 1, int, 1, long long>>(
         TEST_FLOAT__1_SI_1_LL_TASK_ID,
         "test_float__1_si_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<float, 1, unsigned, 1, long long>>(
         TEST_FLOAT__1_UI_1_LL_TASK_ID,
         "test_float__1_ui_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<float, 1, long long, 1, long long>>(
         TEST_FLOAT__1_LL_1_LL_TASK_ID,
         "test_float__1_ll_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<test_task<float, 2, int, 1, long long>>(
         TEST_FLOAT__2_SI_1_LL_TASK_ID,
         "test_float__2_si_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<float, 2, unsigned, 1, long long>>(
         TEST_FLOAT__2_UI_1_LL_TASK_ID,
         "test_float__2_ui_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<float, 2, long long, 1, long long>>(
         TEST_FLOAT__2_LL_1_LL_TASK_ID,
         "test_float__2_ll_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<test_task<float, 3, int, 1, long long>>(
         TEST_FLOAT__3_SI_1_LL_TASK_ID,
         "test_float__3_si_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<float, 3, unsigned, 1, long long>>(
         TEST_FLOAT__3_UI_1_LL_TASK_ID,
         "test_float__3_ui_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<float, 3, long long, 1, long long>>(
         TEST_FLOAT__3_LL_1_LL_TASK_ID,
         "test_float__3_ll_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<test_task<double, 1, int, 1, long long>>(
         TEST_DOUBLE_1_SI_1_LL_TASK_ID,
         "test_double_1_si_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<double, 1, unsigned, 1, long long>>(
         TEST_DOUBLE_1_UI_1_LL_TASK_ID,
         "test_double_1_ui_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<double, 1, long long, 1, long long>>(
         TEST_DOUBLE_1_LL_1_LL_TASK_ID,
         "test_double_1_ll_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<test_task<double, 2, int, 1, long long>>(
         TEST_DOUBLE_2_SI_1_LL_TASK_ID,
         "test_double_2_si_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<double, 2, unsigned, 1, long long>>(
         TEST_DOUBLE_2_UI_1_LL_TASK_ID,
         "test_double_2_ui_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<double, 2, long long, 1, long long>>(
         TEST_DOUBLE_2_LL_1_LL_TASK_ID,
         "test_double_2_ll_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<test_task<double, 3, int, 1, long long>>(
         TEST_DOUBLE_3_SI_1_LL_TASK_ID,
         "test_double_3_si_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<double, 3, unsigned, 1, long long>>(
         TEST_DOUBLE_3_UI_1_LL_TASK_ID,
         "test_double_3_ui_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<
         test_task<double, 3, long long, 1, long long>>(
         TEST_DOUBLE_3_LL_1_LL_TASK_ID,
         "test_double_3_ll_1_ll",
-        TaskFlags::INNER | TaskFlags::REPLICABLE
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::preregister_task<top_level_task>(
-        TOP_LEVEL_TASK_ID, "top_level", TaskFlags::INNER | TaskFlags::REPLICABLE
+        TOP_LEVEL_TASK_ID,
+        "top_level",
+        TaskFlags::INNER | TaskFlags::REPLICABLE,
+        Legion::Processor::LOC_PROC
     );
     LegionSolvers::initialize(false);
     Legion::Runtime::set_top_level_task_id(TOP_LEVEL_TASK_ID);


### PR DESCRIPTION
This is some groundwork for the non-kokkos based tasks.